### PR TITLE
Update node version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,13 @@ cache:
     directories:
     - "$HOME/.composer/cache"
 
+env:
+    - NODE_RELEASE=12.x
+
+before_install:
+    - sudo rm -rf ~/.nvm - curl -sL "https://deb.nodesource.com/setup_${NODE_RELEASE}" | sudo -E bash -
+    - sudo apt-get install -y nodejs
+
 install:
 - composer update --no-progress --no-suggest --ansi --prefer-dist
 


### PR DESCRIPTION
This should hopefully get rid of the minimum nodejs warning of semantic-release