### PR TITLE
Local adapter gracefully fails if file doesnt exist

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
 		"google/cloud-secret-manager": "^2.2",
 		"guzzlehttp/guzzle": "^7.0",
 		"mockery/mockery": "^1.6.12",
-		"phpunit/phpunit": "^10.5 || ^11.0",
+		"phpunit/phpunit": "^10.5 || ^11.0 || ^12.0 || ^13.0",
 		"psr/simple-cache": "^1.0 || ^2.0 || ^3.0",
 		"symfony/config": "^5.3 || ^6.0 || ^7.0 || ^8.0",
 		"symfony/dependency-injection": "^5.0 || ^6.0 || ^7.0 || ^8.0",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- https://phpunit.de/manual/current/en/appendixes.configuration.html -->
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" colors="true" bootstrap="vendor/autoload.php" cacheDirectory=".phpunit.cache">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd" colors="true" bootstrap="vendor/autoload.php" cacheDirectory=".phpunit.cache">
   <php>
     <ini name="error_reporting" value="-1"/>
     <ini name="memory_limit" value="-1"/>

--- a/src/Adapter/Cache/PSR16Cache/.gitattributes
+++ b/src/Adapter/Cache/PSR16Cache/.gitattributes
@@ -1,0 +1,1 @@
+Tests export-ignore

--- a/src/Adapter/Cache/PSR6Cache/.gitattributes
+++ b/src/Adapter/Cache/PSR6Cache/.gitattributes
@@ -1,0 +1,1 @@
+Tests export-ignore

--- a/src/Adapter/Chain/.gitattributes
+++ b/src/Adapter/Chain/.gitattributes
@@ -1,0 +1,1 @@
+Tests export-ignore

--- a/src/Adapter/GCP/SecretsManager/.gitattributes
+++ b/src/Adapter/GCP/SecretsManager/.gitattributes
@@ -1,0 +1,1 @@
+Tests export-ignore

--- a/src/Adapter/Hashicorp/Vault/.gitattributes
+++ b/src/Adapter/Hashicorp/Vault/.gitattributes
@@ -1,0 +1,1 @@
+Tests export-ignore

--- a/src/Adapter/Local/JSONFile/.gitattributes
+++ b/src/Adapter/Local/JSONFile/.gitattributes
@@ -1,0 +1,1 @@
+Tests export-ignore

--- a/src/Adapter/Local/JSONFile/LocalJSONFileAdapter.php
+++ b/src/Adapter/Local/JSONFile/LocalJSONFileAdapter.php
@@ -59,8 +59,8 @@ class LocalJSONFileAdapter extends AbstractAdapter
             throw new SecretNotFoundException($key, $e);
         }
 
-        $keys    = array_column($secrets, 'key');
-        $index   = array_search($key, $keys, true);
+        $keys  = array_column($secrets, 'key');
+        $index = array_search($key, $keys, true);
 
         if ($index === false || $index === null) {
             throw new SecretNotFoundException($key);

--- a/src/Adapter/Local/JSONFile/LocalJSONFileAdapter.php
+++ b/src/Adapter/Local/JSONFile/LocalJSONFileAdapter.php
@@ -53,7 +53,12 @@ class LocalJSONFileAdapter extends AbstractAdapter
      */
     public function getSecret(string $key, ?array $options = []): Secret
     {
-        $secrets = $this->loadSecrets();
+        try {
+            $secrets = $this->loadSecrets();
+        } catch (\Exception $e) {
+            throw new SecretNotFoundException($key, $e);
+        }
+
         $keys    = array_column($secrets, 'key');
         $index   = array_search($key, $keys, true);
 
@@ -130,6 +135,10 @@ class LocalJSONFileAdapter extends AbstractAdapter
      */
     private function loadSecrets(): array
     {
+        if (!file_exists($this->secretsFile)) {
+            throw new \Exception('Secrets file does not exist.');
+        }
+
         return json_decode(file_get_contents($this->secretsFile), true, 512, JSON_THROW_ON_ERROR);
     }
 

--- a/src/Adapter/Local/JSONFile/Tests/LocalJSONFileAdapterTest.php
+++ b/src/Adapter/Local/JSONFile/Tests/LocalJSONFileAdapterTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Secretary\Adapter\Local\JSONFile\Tests;
+namespace Secretary\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Secretary\Adapter\Local\JSONFile\LocalJSONFileAdapter;
@@ -99,7 +99,7 @@ class LocalJSONFileAdapterTest extends TestCase
     public function testPutSecretAddsNewSecret(): void
     {
         $adapter = new LocalJSONFileAdapter(['file' => $this->tempFile]);
-        $secret = new Secret('new/key', 'new-value');
+        $secret  = new Secret('new/key', 'new-value');
 
         $result = $adapter->putSecret($secret);
 
@@ -110,7 +110,7 @@ class LocalJSONFileAdapterTest extends TestCase
     public function testPutSecretUpdatesExistingSecret(): void
     {
         $adapter = new LocalJSONFileAdapter(['file' => $this->tempFile]);
-        $secret = new Secret('db/password', 'updated');
+        $secret  = new Secret('db/password', 'updated');
 
         $adapter->putSecret($secret);
 
@@ -139,7 +139,7 @@ class LocalJSONFileAdapterTest extends TestCase
     public function testDeleteSecret(): void
     {
         $adapter = new LocalJSONFileAdapter(['file' => $this->tempFile]);
-        $secret = new Secret('api/token', 'tok123');
+        $secret  = new Secret('api/token', 'tok123');
 
         $adapter->deleteSecret($secret);
 

--- a/src/Adapter/Local/JSONFile/Tests/LocalJSONFileAdapterTest.php
+++ b/src/Adapter/Local/JSONFile/Tests/LocalJSONFileAdapterTest.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Secretary\Adapter\Local\JSONFile\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Secretary\Adapter\Local\JSONFile\LocalJSONFileAdapter;
+use Secretary\Exception\SecretNotFoundException;
+use Secretary\Secret;
+
+class LocalJSONFileAdapterTest extends TestCase
+{
+    private string $tempFile;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->tempFile = tempnam(sys_get_temp_dir(), 'secretary_test_');
+        file_put_contents($this->tempFile, json_encode([
+            ['key' => 'db/password', 'value' => 's3cret'],
+            ['key' => 'api/token', 'value' => 'tok123', 'metadata' => ['env' => 'test']],
+        ]));
+    }
+
+    protected function tearDown(): void
+    {
+        if (file_exists($this->tempFile)) {
+            unlink($this->tempFile);
+        }
+
+        parent::tearDown();
+    }
+
+    public function testConstructThrowsWhenConfigIsEmpty(): void
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Configuration is required.');
+
+        new LocalJSONFileAdapter([]);
+    }
+
+    public function testConstructThrowsWhenFileMissing(): void
+    {
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('`file` is a required config.');
+
+        new LocalJSONFileAdapter(['foo' => 'bar']);
+    }
+
+    public function testGetSecretReturnsSecret(): void
+    {
+        $adapter = new LocalJSONFileAdapter(['file' => $this->tempFile]);
+
+        $secret = $adapter->getSecret('db/password');
+
+        $this->assertInstanceOf(Secret::class, $secret);
+        $this->assertSame('db/password', $secret->getKey());
+        $this->assertSame('s3cret', $secret->getValue());
+    }
+
+    public function testGetSecretReturnsMetadata(): void
+    {
+        $adapter = new LocalJSONFileAdapter(['file' => $this->tempFile]);
+
+        $secret = $adapter->getSecret('api/token');
+
+        $this->assertSame(['env' => 'test'], $secret->getMetadata());
+    }
+
+    public function testGetSecretThrowsWhenKeyNotFound(): void
+    {
+        $adapter = new LocalJSONFileAdapter(['file' => $this->tempFile]);
+
+        $this->expectException(SecretNotFoundException::class);
+        $this->expectExceptionMessage('No secret was found with the key: "nonexistent"');
+
+        $adapter->getSecret('nonexistent');
+    }
+
+    public function testGetSecretThrowsWhenFileDoesNotExist(): void
+    {
+        $adapter = new LocalJSONFileAdapter(['file' => '/tmp/secretary_nonexistent_file.json']);
+
+        $this->expectException(SecretNotFoundException::class);
+        $this->expectExceptionMessage('No secret was found with the key: "any-key"');
+
+        try {
+            $adapter->getSecret('any-key');
+        } catch (SecretNotFoundException $e) {
+            $this->assertNotNull($e->getPrevious(), 'Expected a previous exception to be set');
+            $this->assertSame('Secrets file does not exist.', $e->getPrevious()->getMessage());
+
+            throw $e;
+        }
+    }
+
+    public function testPutSecretAddsNewSecret(): void
+    {
+        $adapter = new LocalJSONFileAdapter(['file' => $this->tempFile]);
+        $secret = new Secret('new/key', 'new-value');
+
+        $result = $adapter->putSecret($secret);
+
+        $this->assertSame('new/key', $result->getKey());
+        $this->assertSame('new-value', $result->getValue());
+    }
+
+    public function testPutSecretUpdatesExistingSecret(): void
+    {
+        $adapter = new LocalJSONFileAdapter(['file' => $this->tempFile]);
+        $secret = new Secret('db/password', 'updated');
+
+        $adapter->putSecret($secret);
+
+        $retrieved = $adapter->getSecret('db/password');
+        $this->assertSame('updated', $retrieved->getValue());
+    }
+
+    public function testDeleteSecretByKey(): void
+    {
+        $adapter = new LocalJSONFileAdapter(['file' => $this->tempFile]);
+
+        $adapter->deleteSecretByKey('db/password');
+
+        $this->expectException(SecretNotFoundException::class);
+        $adapter->getSecret('db/password');
+    }
+
+    public function testDeleteSecretByKeyThrowsWhenNotFound(): void
+    {
+        $adapter = new LocalJSONFileAdapter(['file' => $this->tempFile]);
+
+        $this->expectException(SecretNotFoundException::class);
+        $adapter->deleteSecretByKey('nonexistent');
+    }
+
+    public function testDeleteSecret(): void
+    {
+        $adapter = new LocalJSONFileAdapter(['file' => $this->tempFile]);
+        $secret = new Secret('api/token', 'tok123');
+
+        $adapter->deleteSecret($secret);
+
+        $this->expectException(SecretNotFoundException::class);
+        $adapter->getSecret('api/token');
+    }
+}

--- a/src/Adapter/Local/JSONFile/Tests/LocalJSONFileAdapterTest.php
+++ b/src/Adapter/Local/JSONFile/Tests/LocalJSONFileAdapterTest.php
@@ -2,6 +2,12 @@
 
 declare(strict_types=1);
 
+/*
+ * @author    Aaron Scherer <aequasi@gmail.com>
+ * @date      2019
+ * @license   https://opensource.org/licenses/MIT
+ */
+
 namespace Secretary\Tests;
 
 use PHPUnit\Framework\TestCase;

--- a/src/Adapter/Local/JSONFile/composer.json
+++ b/src/Adapter/Local/JSONFile/composer.json
@@ -22,7 +22,7 @@
     },
     "require-dev":       {
         "mockery/mockery": "^1.6.12",
-        "phpunit/phpunit": "^10.5 || ^11.0"
+        "phpunit/phpunit": "^10.5 || ^11.0 || ^12.0 || ^13.0"
     },
     "autoload":          {
         "psr-4": {

--- a/src/Adapter/Local/JSONFile/composer.json
+++ b/src/Adapter/Local/JSONFile/composer.json
@@ -31,7 +31,7 @@
     },
     "autoload-dev":      {
         "psr-4": {
-            "Secretary\\Adapter\\Local\\JSONFile\\Tests\\": "Tests/"
+            "Secretary\\Tests\\": "Tests/"
         }
     }
 }

--- a/src/Core/.gitattributes
+++ b/src/Core/.gitattributes
@@ -1,0 +1,1 @@
+Tests export-ignore

--- a/src/Core/composer.json
+++ b/src/Core/composer.json
@@ -42,7 +42,7 @@
     },
     "autoload-dev":      {
         "psr-4": {
-            "Secretary\\Tests\\": "tests/"
+            "Secretary\\Tests\\": "Tests/"
         }
     }
 }


### PR DESCRIPTION
* fixes #20

I also added `.gitattributes` for all packages, to avoid this issue:
```
PHP Fatal error:  Cannot redeclare class Secretary\Tests\ManagerTest (previously declared in ~/secretary/php/src/Core/Tests/ManagerTest.php:22) in ~/secretary/php/src/Bundle/SecretaryBundle/vendor/secretary/core/Tests/ManagerTest.php on line 24
Stack trace:
#0 ~/secretary/php/vendor/phpunit/phpunit/src/Runner/TestSuiteLoader.php(116): require_once()
``` 